### PR TITLE
改造: タイプライターのようなキャリッジ・リターン表示

### DIFF
--- a/kernel/console.cpp
+++ b/kernel/console.cpp
@@ -19,6 +19,8 @@ void Console::PutString(const char* s) {
   while (*s) {
     if (*s == '\n') {
       Newline();
+    } else if (*s == '\r') {
+      CarriageReturn();
     } else if (cursor_column_ < kColumns - 1) {
       WriteAscii(writer_, 8 * cursor_column_, 16 * cursor_row_, *s, fg_color_);
       buffer_[cursor_row_][cursor_column_] = *s;
@@ -44,4 +46,8 @@ void Console::Newline() {
     }
     memset(buffer_[kRows - 1], 0, kColumns + 1);
   }
+}
+
+void Console::CarriageReturn() {
+  cursor_column_ = 0;
 }

--- a/kernel/console.hpp
+++ b/kernel/console.hpp
@@ -12,6 +12,7 @@ class Console {
 
  private:
   void Newline();
+  void CarriageReturn();
 
   PixelWriter& writer_;
   const PixelColor fg_color_, bg_color_;

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -110,6 +110,8 @@ extern "C" void KernelMain(const FrameBufferConfig& frame_buffer_config) {
     *pixel_writer, kDesktopFGColor, kDesktopBGColor
   };
   printk("Welcome to MikanOS!\n");
+  printk("--Test carriage return--\n");
+  printk("___\r ++\r  ^\n");
   // #@@range_end(draw_desktop)
 
   // #@@range_begin(draw_mouse_cursor)


### PR DESCRIPTION
## 機能
コンソールが`\r`を受け取ったとき、以下の動作を行うようにする。
- カーソルは行頭へ戻る
- カーソルは次の行へ進まない
- 新たに描かれる文字は、既存の文字に重ねて描かれる

## 動作結果
```c
___\r
 ++\r
  ^\n
```
をprintすると、文字`_+^`が重なったものが描画された
![](https://gyazo.com/9a8b155327efa8911f7b64579ce7d449.png)