### PR TITLE
改造: ファイル名の長名を表示する

### DIFF
--- a/kernel/fat.cpp
+++ b/kernel/fat.cpp
@@ -38,5 +38,36 @@ void ReadName(const DirectoryEntry& entry, char* base, char* ext) {
   }
 }
 // #@@range_end(read_name)
+void ReadLongName(const DirectoryEntry entries[], int i, char name[]) {
+  name[0] = 0;
+  const uint8_t LAST_LONG_ENTRY = 0x40;
+  if (i <= 0) return;
+  if (entries[i - 1].attr != Attribute::kLongName) return;
 
-} // namespace fat
+  LFNDirectoryEntry* entry = (LFNDirectoryEntry*) &entries[i - 1];
+  if (entry->LDIR_Type != 0) return;
+  if (entry->LDIR_FstClusLO[0] != 0) return;
+  if (entry->LDIR_FstClusLO[1] != 0) return;
+
+  uint8_t ord = entry->LDIR_Ord;
+  char16_t longName[14];
+  if ((ord == 0x01) || (ord & LAST_LONG_ENTRY)) {
+    for (int i = 0; i < 5; i++) longName[i] = entry->LDIR_Name1[i];
+    for (int i = 0; i < 6; i++) longName[5 + i] = entry->LDIR_Name2[i];
+    for (int i = 0; i < 2; i++) longName[11 + i] = entry->LDIR_Name3[i];
+  }
+  longName[13] = 0;
+  // return
+  String16toString8(longName, name);
+}
+void String16toString8(char16_t from[], char to[]) {
+  int i = 0;
+  char *c;
+  do {
+    c = (char*)(&(from[i]));
+    to[i] = *c;
+    i++;
+  } while (*c != 0);
+}
+
+}  // namespace fat

--- a/kernel/fat.hpp
+++ b/kernel/fat.hpp
@@ -70,6 +70,18 @@ struct DirectoryEntry {
   }
 } __attribute__((packed));
 
+struct LFNDirectoryEntry {
+  // 解説は http://elm-chan.org/docs/fat.html#lfn より
+  uint8_t LDIR_Ord;           // このエントリがLFNエントリ(1個のLFNを構成するエントリ群)のどの部分かを示すシーケンス番号(1～20)。1がLFNの先頭部を意味する。LAST_LONG_ENTRYフラグ(0x40)が立っているときは、LFNエントリの開始であることを示す。
+  char16_t LDIR_Name1[5];     // 名前。1文字目～5文字目。Unicode(UTF-16LE)で格納される。
+  uint8_t LDIR_Attr;          // LFNアトリビュート。このエントリがLFNエントリの一部であることを示すため、ATTR_LONG_NAMEでなければならない。
+  uint8_t LDIR_Type;          // LFNのタイプ。常に0でなければならず、0以外は予約。
+  uint8_t LDIR_Chksum;        // このLFNエントリと結びつけられているSFNエントリのチェックサム。
+  char16_t LDIR_Name2[6];     // 名前。6文字目～11文字目。
+  uint8_t LDIR_FstClusLO[2];  // 古いディスクユーティリティによる危険の可能性を避けるため、0がセットされる。
+  char16_t LDIR_Name3[2];     // 名前。12文字目～13文字目。
+} __attribute__((packed));
+
 extern BPB* boot_volume_image;
 void Initialize(void* volume_image);
 
@@ -101,4 +113,12 @@ T* GetSectorByCluster(unsigned long cluster) {
  */
 void ReadName(const DirectoryEntry& entry, char* base, char* ext);
 
+/** @brief ディレクトリエントリの長名を取得する。長名が無効であればヌル文字で始まる文字列を返す。
+ *
+ * @param entries
+ * @param i
+ * @param name  長名（size14以上の配列）
+ */
+void ReadLongName(const DirectoryEntry entries[], int i, char name[]);
+void String16toString8(char16_t from[], char to[]);
 } // namespace fat

--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -151,7 +151,7 @@ void Terminal::ExecuteLine() {
       }
 
       if (ext[0]) {
-        sprintf(s, "%s.%s\n", base, ext);
+        sprintf(s, "%s [%s]\n", base, ext);
       } else {
         sprintf(s, "%s\n", base);
       }

--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -139,19 +139,21 @@ void Terminal::ExecuteLine() {
        fat::boot_volume_image->bytes_per_sector / sizeof(fat::DirectoryEntry)
        * fat::boot_volume_image->sectors_per_cluster;
     char base[9], ext[4];
+    char longName[14];
     char s[64];
     for (int i = 0; i < entries_per_cluster; ++i) {
       ReadName(root_dir_entries[i], base, ext);
+      ReadLongName(root_dir_entries, i, longName);
       if (base[0] == 0x00) {
-        break;
+          break;
       } else if (static_cast<uint8_t>(base[0]) == 0xe5) {
-        continue;
+          continue;
       } else if (root_dir_entries[i].attr == fat::Attribute::kLongName) {
-        continue;
+          continue;
       }
 
       if (ext[0]) {
-        sprintf(s, "%s [%s]\n", base, ext);
+        sprintf(s, "%s [%s] %s\n", base, ext, longName);
       } else {
         sprintf(s, "%s\n", base);
       }


### PR DESCRIPTION
ファイル名の表示を、13文字までのASCIIコードで書かれた長名に対応した。
14文字以上であったり、ASCIIコードでないファイル名には対応していない。

## 改造前
9文字以上のファイル名や、ドットが複数付いているファイル名の表示に対応していない。
また、大文字・小文字の区別もない。
例えば、`a.e.txt`というファイルは以下のように、`AE~1.TXT`と表示されてしまう。
![](https://user-images.githubusercontent.com/31231761/106725148-63a16000-664c-11eb-9784-568534580883.png)

## 改造後
以下のように、`短名 [拡張子] 長名`を表示するようにした。
`a.e.txt`というファイル名がそのまま表示されていることがわかる。
![](https://gyazo.com/15927a689b73a6572d05e2e39019adc4.png)

## 解説
長名に拡張されたFATディレクトリエントリのデータ構造は以下のとおりである。
https://github.com/Durun/mikanos/blob/506d76d743d9453bf0ebe12c95e457fffc6961c9/kernel/fat.hpp#L73-L83

長名を取得するには、該当エントリの前のエントリを参照する必要がある。
そこで、長名を取得する以下の関数では、ディレクトリエントリ全体の配列`entries[]`と添字`i`をもとに、`entries[i-1]`を参照している。
https://github.com/Durun/mikanos/blob/506d76d743d9453bf0ebe12c95e457fffc6961c9/kernel/fat.cpp#L41-L62

## 参考
- [FATファイルシステムのしくみと操作法](http://elm-chan.org/docs/fat.html#lfn)